### PR TITLE
Use setTimeout which is not throttled by inactive tab in browsers

### DIFF
--- a/lib/game/PWGameClient.ts
+++ b/lib/game/PWGameClient.ts
@@ -10,8 +10,7 @@ import type { CustomBotEvents, MergedEvents, WorldEvents } from "../types/events
 import Queue from "../util/Queue.js";
 import type { OmitRecursively, Optional, Promisable } from "../types/misc.js";
 import { isCustomPacket } from "../util/Misc.js";
-
-import { setTimeout } from "worker-timers"
+import { customSetTimeout } from "../util/Timeout.js";
 
 type SafeCheck<K extends keyof MergedEvents, State extends Partial<{ [K in keyof MergedEvents]: any }>> = State extends CustomBotEvents ? never : State[K];
 
@@ -168,7 +167,7 @@ export default class PWGameClient
                         init = true; res(this);
 
                         // Give the client the init again as they might could have missed it even by a few milliseconds.
-                        return setTimeout(() => {
+                        return customSetTimeout(() => {
                             // TODO: deduplicate this part.
                             if (this.hooks.length) {
                                 try {

--- a/lib/game/PWGameClient.ts
+++ b/lib/game/PWGameClient.ts
@@ -11,6 +11,8 @@ import Queue from "../util/Queue.js";
 import type { OmitRecursively, Optional, Promisable } from "../types/misc.js";
 import { isCustomPacket } from "../util/Misc.js";
 
+import { setTimeout } from "worker-timers"
+
 type SafeCheck<K extends keyof MergedEvents, State extends Partial<{ [K in keyof MergedEvents]: any }>> = State extends CustomBotEvents ? never : State[K];
 
 export default class PWGameClient

--- a/lib/util/Queue.ts
+++ b/lib/util/Queue.ts
@@ -1,9 +1,9 @@
-import { setTimeout } from "worker-timers"
+import { customSetTimeout } from "./Timeout.js";
 
 export default class Queue {
     private _queue: Array<{ priority: boolean; func(): void;}> = [];
 
-    timeout: null | number;
+    timeout: NodeJS.Timeout | null | number;
     tokenLimit: number;
     interval: number;
 
@@ -40,7 +40,7 @@ export default class Queue {
         }
 
         if (this._queue.length !== 0 && this.timeout === null) {
-            this.timeout = setTimeout(() => {
+            this.timeout = customSetTimeout(() => {
                 this.timeout = null;
                 this.check();
             }, this.tokens < this.tokenLimit ? 1 : Math.max(0, this.lastReset + this.interval - Date.now()));

--- a/lib/util/Queue.ts
+++ b/lib/util/Queue.ts
@@ -3,6 +3,9 @@ import { customSetTimeout } from "./Timeout.js";
 export default class Queue {
     private _queue: Array<{ priority: boolean; func(): void;}> = [];
 
+    /**
+     * Annoyingly settimeout returns timeout object in nodejs, number for anywhere else.
+     */
     timeout: NodeJS.Timeout | null | number;
     tokenLimit: number;
     interval: number;

--- a/lib/util/Queue.ts
+++ b/lib/util/Queue.ts
@@ -1,10 +1,9 @@
+import { setTimeout } from "worker-timers"
+
 export default class Queue {
     private _queue: Array<{ priority: boolean; func(): void;}> = [];
 
-    /**
-     * Annoyingly settimeout returns timeout object in nodejs, number for anywhere else.
-     */
-    timeout: NodeJS.Timeout | null | number;
+    timeout: null | number;
     tokenLimit: number;
     interval: number;
 

--- a/lib/util/Timeout.ts
+++ b/lib/util/Timeout.ts
@@ -1,0 +1,13 @@
+import { setTimeout as workerSetTimeout } from "worker-timers";
+import * as jsEnv from "browser-or-node";
+
+export function customSetTimeout(callback: () => void, ms: number): number | NodeJS.Timeout {
+    if (jsEnv.isBrowser) {
+        // setTimeout in browsers timeout for longer, when the tab is inactive due to throttling.
+        // However, running timeout in web worker avoids an inactive tab throttling problem, because timeouts in web worker are not throttled.
+        return workerSetTimeout(callback, ms);
+    } else {
+        // Other environments may not support web workers
+        return setTimeout(callback, ms);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -7,11 +7,9 @@
     "build": "rimraf esm cm && tsc -p tsconfig-cm.json & tsc -p tsconfig-esm.json && ncp lib/types esm/types",
     "build:proto": "node scripts/build-proto.mjs && buf generate",
     "build:mappings": "node scripts/build-mappings.mjs",
-
     "browsify": "rimraf browser && npm-run-all -p browsify-*",
     "browsify-prod": "cross-env NODE_ENV=production webpack --mode=production",
     "browsify-dev": "cross-env NODE_ENV=development webpack --mode=development",
-
     "prepare": "run-p build:* && run-s build browsify"
   },
   "exports": {
@@ -20,7 +18,8 @@
     "require": "./cm/index.js"
   },
   "keywords": [
-    "PixelWalker", "Core"
+    "PixelWalker",
+    "Core"
   ],
   "author": "Doomester",
   "repository": {
@@ -44,6 +43,7 @@
   "dependencies": {
     "@bufbuild/protobuf": "~2.2.3",
     "isows": "~1.0.6",
-    "tslib": "~2.8.1"
+    "tslib": "~2.8.1",
+    "worker-timers": "^8.0.20"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "~2.2.3",
+    "browser-or-node": "^3.0.0",
     "isows": "~1.0.6",
     "tslib": "~2.8.1",
     "worker-timers": "^8.0.20"


### PR DESCRIPTION
This PR substitutes `setTimeout` calls with `customSetTimeout`.
`customSetTimeout` calls `workerSetTimeout` on browser environments, which runs timeouts in web workers, and keeps timeout behavior same on non-browser environments.
Timeouts in web workers are immune to inactive tab throttling - a feature where `setTimeout` lasts longer in browsers on inactive tabs to save CPU resources.
Longer timeouts are not desirable for this library, hence why this PR was made.